### PR TITLE
Replace unpinned actions with pinned action

### DIFF
--- a/.github/workflows/sign-tag.yml
+++ b/.github/workflows/sign-tag.yml
@@ -1,38 +1,31 @@
 name: Sign Git Tag with Gitsign
-
 on:
   push:
     tags:
       - '*'
-
 jobs:
   sign-tag:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
-
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-
-    - name: Get the tag name
-      id: tag_name
-      run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
-    - name: Debug, remove me later
-      run: echo "The tag is ${{ env.TAG_NAME }}"
-
-    - name: Install gitsign
-      run: |
-        curl -Lo gitsign https://github.com/sigstore/gitsign/releases/download/v0.8.0/gitsign_0.8.0_linux_arm64
-        chmod +x gitsign
-        sudo mv gitsign /usr/local/bin/
-
-    - name: Configure gitsign
-      run: |
-        # https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key#telling-git-about-your-x509-key
-        git config --global gpg.x509.program gitsign
-        git config --global gpg.format x509
-        # FIXME: should this be an annotated tag, e.g. tag.forceSignAnnotated ?
-        git config --global tag.gpgSign
+      - name: Checkout code
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - name: Get the tag name
+        id: tag_name
+        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+      - name: Debug, remove me later
+        run: echo "The tag is ${{ env.TAG_NAME }}"
+      - name: Install gitsign
+        run: |
+          curl -Lo gitsign https://github.com/sigstore/gitsign/releases/download/v0.8.0/gitsign_0.8.0_linux_arm64
+          chmod +x gitsign
+          sudo mv gitsign /usr/local/bin/
+      - name: Configure gitsign
+        run: |
+          # https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key#telling-git-about-your-x509-key
+          git config --global gpg.x509.program gitsign
+          git config --global gpg.format x509
+          # FIXME: should this be an annotated tag, e.g. tag.forceSignAnnotated ?
+          git config --global tag.gpgSign


### PR DESCRIPTION
<!-- minder: pr-remediation-body: { "ContentSha": "87c84fe8da6890a0374ae7b418b45798be7885e6" } -->

This is a Minder automated pull request.

This pull request replaces references to actions by tag to references to actions by SHA.

Verifies that any actions use pinned tags
Pinning an action to a full length commit SHA is currently the only way to use
an action as an immutable release. Pinning to a particular SHA helps mitigate
the risk of a bad actor adding a backdoor to the action's repository, as they
would need to generate a SHA-1 collision for a valid Git object payload.
When selecting a SHA, you should verify it is from the action's repository
and not a repository fork.

For more information, see
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
